### PR TITLE
Issue#214 msteam customization path update

### DIFF
--- a/roles/hcl/component-pack/tasks/setup_customizer.yml
+++ b/roles/hcl/component-pack/tasks/setup_customizer.yml
@@ -52,7 +52,7 @@
     dest:                    "{{ __customizer_js_files_mount }}"
     remote_src:              yes
   with_items:
-   - "{{ __support_folder }}/ms-teams"
+   - "{{ __support_folder }}/ms-teams/customizations/ms-teams/teamsshare"
   when:
    - __setup_teams |bool
 

--- a/roles/hcl/component-pack/tasks/setup_customizer.yml
+++ b/roles/hcl/component-pack/tasks/setup_customizer.yml
@@ -52,7 +52,7 @@
     dest:                    "{{ __customizer_js_files_mount }}"
     remote_src:              yes
   with_items:
-   - "{{ __support_folder }}/ms-teams/customizations/ms-teams/teamsshare"
+   - "{{ __support_folder }}/ms-teams/customizations/ms-teams"
   when:
    - __setup_teams |bool
 


### PR DESCRIPTION
Fixes #214

Update js path to align with customization config `ms-teams/teamsshare/connections-teams-share-integration.js`.